### PR TITLE
DP-169 Restricted admin can not access packages tab even when 'packages' tab was selected on widget

### DIFF
--- a/src/Components/RestrictedAdmin.php
+++ b/src/Components/RestrictedAdmin.php
@@ -231,6 +231,7 @@ class RestrictedAdmin
                 array("component" => "app/*", "verbMask" => VerbsMask::GET_MASK),
                 array("component" => "*", "verbMask" => VerbsMask::GET_MASK | VerbsMask::POST_MASK, "serviceName" => "logs"),
                 array("component" => "*", "verbMask" => VerbsMask::GET_MASK | VerbsMask::POST_MASK, "serviceName" => "files"),
+                array("component" => "*", "verbMask" => VerbsMask::GET_MASK, "serviceName" => "system"),
             ),
             "limits" => array(
                 array("component" => "limit/*", "verbMask" => VerbsMask::getFullAccessMask()),


### PR DESCRIPTION

- Add system/* GET service access for packages tab