### PR TITLE
Merge 7.7 release branch into develop

### DIFF
--- a/database/migrations/2026_07_07_000000_make_service_report_service_name_nullable.php
+++ b/database/migrations/2026_07_07_000000_make_service_report_service_name_nullable.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeServiceReportServiceNameNullable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(
+            'service_report',
+            function (Blueprint $t) {
+                $t->string('service_name')->nullable()->change();
+            }
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table(
+            'service_report',
+            function (Blueprint $t) {
+                $t->string('service_name')->nullable(false)->change();
+            }
+        );
+    }
+}

--- a/src/Http/Middleware/ServiceLevelAudit.php
+++ b/src/Http/Middleware/ServiceLevelAudit.php
@@ -110,6 +110,11 @@ class ServiceLevelAudit
         $serviceName = '';
         if (!is_null($serviceId) && ('' !== $serviceId)) {
             $serviceName = ServiceManager::getServiceNameById($serviceId);
+            if (empty($serviceName)) {
+                // The ServiceManager id->name map is cached forever and can go stale
+                // (e.g. service rows created outside a purge). Fall back to the DB.
+                $serviceName = \DreamFactory\Core\Models\Service::whereId($serviceId)->value('name') ?? '';
+            }
         }
 
         return $serviceName;
@@ -225,7 +230,12 @@ class ServiceLevelAudit
     {
         if (!$this->isFailure($response)) {
             foreach ($reportsData as $report) {
-                ServiceReport::create($report)->save();
+                try {
+                    ServiceReport::create($report);
+                } catch (\Throwable $e) {
+                    // Audit bookkeeping must never fail the request that already succeeded.
+                    \Log::warning('Service audit write failed: ' . $e->getMessage(), ['report' => $report]);
+                }
             }
         }
     }

--- a/src/Models/AdminUser.php
+++ b/src/Models/AdminUser.php
@@ -82,6 +82,6 @@ class AdminUser extends CoreAdminUser
      */
     public static function isRootById($id)
     {
-        return AdminUser::whereId($id)->first()->is_root_admin;
+        return AdminUser::whereId($id)->first()?->is_root_admin ?? false;
     }
 }


### PR DESCRIPTION
Aligns develop with the 7.7 release line — develop is currently missing the 7.7 commits in this repo (found while repointing the release bundle at develop; df-core/df-admin-interface/df-mcp-server/df-agents already have 7.7 merged to develop, this repo does not). Until this merges, the develop-pinned bundle keeps this package on `7.7.x-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)