### PR TITLE
release: 7.7.0 — develop → master cut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /vendor
 /.idea
 composer.phar
+composer.lock
+.phpunit.cache
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "php": "^8.0",
-    "dreamfactory/df-core":   "~1.0",
-    "dreamfactory/df-system": "~0.5"
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core":   "~1.0.4",
+    "dreamfactory/df-system": "~0.6.2"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/database/migrations/2026_07_07_000000_make_service_report_service_name_nullable.php
+++ b/database/migrations/2026_07_07_000000_make_service_report_service_name_nullable.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeServiceReportServiceNameNullable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(
+            'service_report',
+            function (Blueprint $t) {
+                $t->string('service_name')->nullable()->change();
+            }
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table(
+            'service_report',
+            function (Blueprint $t) {
+                $t->string('service_name')->nullable(false)->change();
+            }
+        );
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
          bootstrap="/vagrant/bootstrap/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false">
+         cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="Compliance Testing">
             <directory suffix=".php">./tests/</directory>

--- a/src/Http/Middleware/ServiceLevelAudit.php
+++ b/src/Http/Middleware/ServiceLevelAudit.php
@@ -110,6 +110,11 @@ class ServiceLevelAudit
         $serviceName = '';
         if (!is_null($serviceId) && ('' !== $serviceId)) {
             $serviceName = ServiceManager::getServiceNameById($serviceId);
+            if (empty($serviceName)) {
+                // The ServiceManager id->name map is cached forever and can go stale
+                // (e.g. service rows created outside a purge). Fall back to the DB.
+                $serviceName = \DreamFactory\Core\Models\Service::whereId($serviceId)->value('name') ?? '';
+            }
         }
 
         return $serviceName;
@@ -225,7 +230,12 @@ class ServiceLevelAudit
     {
         if (!$this->isFailure($response)) {
             foreach ($reportsData as $report) {
-                ServiceReport::create($report)->save();
+                try {
+                    ServiceReport::create($report);
+                } catch (\Throwable $e) {
+                    // Audit bookkeeping must never fail the request that already succeeded.
+                    \Log::warning('Service audit write failed: ' . $e->getMessage(), ['report' => $report]);
+                }
             }
         }
     }

--- a/src/Models/AdminUser.php
+++ b/src/Models/AdminUser.php
@@ -82,6 +82,6 @@ class AdminUser extends CoreAdminUser
      */
     public static function isRootById($id)
     {
-        return AdminUser::whereId($id)->first()->is_root_admin;
+        return AdminUser::whereId($id)->first()?->is_root_admin ?? false;
     }
 }

--- a/tests/AccessibleTabsTest.php
+++ b/tests/AccessibleTabsTest.php
@@ -29,7 +29,7 @@ class AccessibleTabsTest extends TestCase
         'id' => 0
     ];
 
-    public function tearDown()
+    public function tearDown(): void
     {
         AdminUser::whereEmail('jdoe@dreamfactory.com')->delete();
         parent::tearDown();

--- a/tests/RestrictedAdminsTest.php
+++ b/tests/RestrictedAdminsTest.php
@@ -63,7 +63,7 @@ class RestrictedAdminsTest extends TestCase
         'is_active' => true
     ];
 
-    public function tearDown()
+    public function tearDown(): void
     {
         AdminUser::whereEmail('jdoe@dreamfactory.com')->delete();
         AdminUser::whereEmail('jdoeRA@dreamfactory.com')->delete();

--- a/tests/RootAdminTest.php
+++ b/tests/RootAdminTest.php
@@ -26,7 +26,7 @@ class RootAdminTest extends TestCase
         'is_root_admin' => true
     ];
 
-    public function tearDown()
+    public function tearDown(): void
     {
         AdminUser::whereEmail('jdoe@dreamfactory.com')->delete();
         parent::tearDown();

--- a/tests/ServiceLevelAuditingTest.php
+++ b/tests/ServiceLevelAuditingTest.php
@@ -25,7 +25,7 @@ class ServiceLevelAuditingTest extends TestCase
         'is_active' => true
     ];
 
-    public function tearDown()
+    public function tearDown(): void
     {
         AdminUser::whereEmail('jdoe@dreamfactory.com')->delete();
         ServiceReport::whereServiceName('Node-test')->delete();


### PR DESCRIPTION
7.7.0 release cut. Highlights: hardened service audit writes, MarkAsRootAdmin null-guard fix, Laravel 13.

After merge, tag **0.6.0** on the merge commit (df-commercial's version refresh consumes the tags). Full release notes: see the 7.7.0 draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)